### PR TITLE
Refactor model_router.py to OOP style, remove some unused imports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ With the popularity of large language models (LLMs), the focus of Language Model
 ## Data
 
 Data is saved to CSV files with timestamps and can optionally be uploaded to S3.
-By default, generated data is saved to `~/data/all-tones-{timestamp}.csv`
+By default, generated data is saved to `./data/all-tones-{timestamp}.csv`
 
 ## Available Tone Types
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ transformers==4.48.1
 datasets==3.2.0
 evaluate==0.4.3
 dynaconf==3.2.7
+torch~=2.6.0
+requests~=2.32.3
+botocore~=1.34.162

--- a/src/action_generate.py
+++ b/src/action_generate.py
@@ -2,15 +2,11 @@
 # // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # // SPDX-License-Identifier: Apache-2.0
 #
-from typing import Optional, Tuple
 import pandas as pd
-from src.completion import get_completion
-from src.prompt_tones import Tone, get_prompt
 from src.data_utils import write_dataset_local, write_dataset_to_s3
 from dynaconf import Dynaconf
-from src.prompt_tones import master_sys_prompt, get_prompt, get_all_tones, Tone
+from src.prompt_tones import get_all_tones, Tone
 import os
-import boto3
 
 from src.data_generation_prompts import *
 from src.model_router import route_completion
@@ -30,46 +26,21 @@ PROMPT_MAP = {
 }
 
 
-def generate_dataset(settings,
-                    dataset_type: str = "witty") -> Tuple[str, pd.DataFrame]:
-    """
-    Generate dataset based on the specified type
-    
-    Args:
-        model: The model to use for generation
-        bedrock_client: Optional bedrock client for AWS models
-        dataset_type: Type of dataset to generate. Must be one of:
-            - witty
-            - professional
-            - summarize
-            - casual
-            - elaborate
-            - shorten
-            - improve
-            - keypoints
-            - proofread
-            - emojify
-    
-    Returns:
-        Tuple[str, pd.DataFrame]: Raw output string and processed DataFrame
-        
-    Raises:
-        ValueError: If dataset_type is not recognized
-    """
+def generate_dataset(
+    settings,
+    dataset_type: str = "witty"
+) -> pd.DataFrame:
     if dataset_type not in PROMPT_MAP:
         valid_types = "\n- ".join(PROMPT_MAP.keys())
         raise ValueError(
             f"Unknown dataset_type: {dataset_type}\n"
             f"Must be one of:\n- {valid_types}"
         )
-    
-    prompt = PROMPT_MAP[dataset_type]
-    print(prompt)
-    raw_output = route_completion(settings, prompt)
-    d = process_raw_output(raw_output, dataset_type)
-    
-    return d
-
+    raw_output = route_completion(
+        settings,
+        [PROMPT_MAP[dataset_type]]
+    )
+    return process_raw_output(raw_output, Tone(dataset_type))
 
 def process_raw_output(output: str, tone: Tone) -> pd.DataFrame:
     """Process raw LLM output into a pandas DataFrame"""
@@ -105,11 +76,11 @@ def generate_tone_data(
         t["tone"] = tone
         t["synthetic_model"] = model_name
         d.append(t)
-        data_dir = os.path.expanduser("~/data")
+        data_dir = os.path.expanduser("./data")
         os.makedirs(data_dir, exist_ok=True)
 
     combined = pd.concat(d, ignore_index=True)
 
-    write_dataset_local(combined, "~/data", "all-tones")
+    write_dataset_local(combined, "./data", "all-tones")
     if upload_s3:
-        write_dataset_to_s3(df, settings.s3_bucket, "generate/all", "csv")
+        write_dataset_to_s3(combined, settings.s3_bucket, "generate/all", "csv")

--- a/src/completion.py
+++ b/src/completion.py
@@ -5,13 +5,10 @@
 import time
 import random
 from botocore.exceptions import ClientError
-from src.prompt_tones import Prompt
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import os
 import json
 import boto3
-import base64
-import sys
 import re
 import requests
 
@@ -24,10 +21,10 @@ def extract_last_assistant_response(data):
     else:
         return data
 
-def get_completion(settings, prompt, system_prompt=None, max_retries=3, initial_delay=1):
-
+def get_bedrock_completion(settings, prompt, system_prompt=None):
     bedrock_client = boto3.client(service_name="bedrock-runtime", region_name=settings.region)
-
+    max_retries = 2
+    initial_delay = 1
     for attempt in range(max_retries):
         try:
             inference_config = {
@@ -72,7 +69,7 @@ def get_completion(settings, prompt, system_prompt=None, max_retries=3, initial_
             print(f"A client error occurred: {message}")
             raise
 
-def batch_get_completions(settings, prompts, system_prompts=None, max_concurrent=100):
+def batch_get_bedrock_completions(settings, prompts, system_prompts=None, max_concurrent=100):
 
     if system_prompts is None:
         system_prompts = [None] * len(prompts)
@@ -80,13 +77,6 @@ def batch_get_completions(settings, prompts, system_prompts=None, max_concurrent
         raise ValueError("The number of system prompts must match the number of prompts")
 
     results = [None] * len(prompts)
-    
-    def process_prompt(index, prompt, system_prompt):
-        try:
-            response = get_completion(settings, prompt, system_prompt)
-            return index, response
-        except Exception as e:
-            return index, f"Error processing prompt {index}: {str(e)}"
 
     # Add rate limiting at batch level
     completed_requests = 0
@@ -101,7 +91,8 @@ def batch_get_completions(settings, prompts, system_prompts=None, max_concurrent
                     process_prompt,
                     i,
                     prompts[i],
-                    system_prompts[i]
+                    system_prompts[i],
+                    settings
                 ) for i in range(batch_start, batch_end)
             ]
             
@@ -116,21 +107,16 @@ def batch_get_completions(settings, prompts, system_prompts=None, max_concurrent
 
     return results
 
+def process_prompt(index, prompt, system_prompt, settings):
+    try:
+        response = get_bedrock_completion(settings, prompt, system_prompt)
+        return index, response
+    except Exception as e:
+        return index, f"Error processing prompt {index}: {str(e)}"
+
 # Add this new function for future use
-def bedrock_batch_inference(modelId, bedrock_client, prompts, system_prompt, aws_account, tone):
-    """
-    Future implementation of Bedrock's official batch inference API.
-    Currently stored for later use.
-    
-    Args:
-        modelId: The Bedrock model ID
-        bedrock_client: Boto3 Bedrock client
-        prompts: List of prompts to process
-        system_prompt: System prompt to use
-        aws_account: AWS account number
-        tone: Current tone being processed
-    """
-    data_dir = os.path.expanduser('~/data')
+def bedrock_batch_inference(model_id, bedrock_client, prompts, system_prompt, aws_account, tone):
+    data_dir = os.path.expanduser('./data')
     input_file = os.path.join(data_dir, 'batch_input.jsonl')
     
     # Create JSONL records
@@ -172,7 +158,7 @@ def bedrock_batch_inference(modelId, bedrock_client, prompts, system_prompt, aws
     bedrock = boto3.client(service_name="bedrock")
     response = bedrock.create_model_invocation_job(
         roleArn=f"arn:aws:iam::{aws_account}:role/BedrockBatchInferenceRole",
-        modelId=modelId,
+        modelId=model_id,
         jobName=f"tone-transform-{tone}-{int(time.time())}",
         inputDataConfig=input_config,
         outputDataConfig=output_config


### PR DESCRIPTION
### Description of changes

- Refactor ```model_router.py``` to OOP.
- Move the ```process_prompt``` function definition outside of the batch inference function.
- Remove out-of-date docstring from ```bedrock_batch_inference```.
- Add requests and botocore to ```requirements.txt```.
- Remove unused imports.
- Minor refactor with ```main.py``` arg parsing.
- Change default data directory to project root for more convenience with the IDE.

### Testing

Run the example generate command in the README, more specifically

```
python main.py generate --type witty --model nova-lite
```

Inference is still broken due to some settings being missing.
