### PR TITLE
Fix some generate and inference commands

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -1,33 +1,42 @@
 [default]
 region = 'us-east-1'
+data_dir = './data'
 
 [haiku-3]
 model = 'anthropic.claude-3-haiku-20240307-v1:0'
+endpoint_type = 'bedrock'
 
 [haiku-3-5]
 model = 'us.anthropic.claude-3-5-haiku-20241022-v1:0'
+endpoint_type = 'bedrock'
 
 [sonnet-3]
 model = 'anthropic.claude-3-sonnet-20240229-v1:0'
+endpoint_type = 'bedrock'
 
 [sonnet-3-5]
 model = 'us.anthropic.claude-3-5-sonnet-20241022-v2:0'
+endpoint_type = 'bedrock'
 
 [nova-lite]
 model = 'amazon.nova-lite-v1:0'
+endpoint_type = 'bedrock'
 
 [haiku-3-5-cross]
-model = "arn:aws:bedrock:us-east-1:{aws_account}:inference-profile/us.anthropic.claude-3-5-haiku-20241022-v1:0"
+model = 'arn:aws:bedrock:us-east-1:{aws_account}:inference-profile/us.anthropic.claude-3-5-haiku-20241022-v1:0'
+endpoint_type = 'bedrock'
 
 [phi-3-5-4B]
-model = "Phi-3-5-mini-instruct"
-hf_name = "microsoft/Phi-3.5-mini-instruct"
+model = 'Phi-3-5-mini-instruct'
+hf_name = 'microsoft/Phi-3.5-mini-instruct'
+endpoint_type = 'sagemaker'
 
 [qwen-2-5-1-5B]
-model = "Qwen2-5-1-5B-Instruct"
-hf_name = "Qwen/Qwen2.5-1.5B-Instruct"
+model = 'Qwen2-5-1-5B-Instruct'
+hf_name = 'Qwen/Qwen2.5-1.5B-Instruct'
+endpoint_type = 'sagemaker'
 
 [phi-3-ollama]
-model = "Phi-3-5-mini-instruct"
-hf_name = "microsoft/Phi-3.5-mini-instruct"
-
+model = 'phi3'
+hf_name = 'microsoft/Phi-3.5-mini-instruct'
+endpoint_type = 'ollama'

--- a/src/action_human_judge_parsing.py
+++ b/src/action_human_judge_parsing.py
@@ -49,13 +49,12 @@ def get_human_vs_judge_dataset(args):
     all_data = pd.read_csv(os.path.join(folder_path, last_file))
 
     rewrite = pd.concat(records, axis = 0)
-    # TODO: Where to find this rewrite_score? Are we still assuming one file per tone?
     rewrite.rewrite_score = rewrite.rewrite_score.astype(int)
     rewrite['key'] = rewrite[['tone', 'model','input']].astype(str).agg('_'.join, axis=1)
     rewrite['key'] = rewrite['key'].astype(str)
 
 
-    subset = pd.read_csv('~/data/all_small.csv')
+    subset = pd.read_csv('./data/all_small.csv')
 
     subset['human_rating'] = ''
 

--- a/src/action_inference.py
+++ b/src/action_inference.py
@@ -2,18 +2,9 @@
 # // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # // SPDX-License-Identifier: Apache-2.0
 #
-import boto3
 from dynaconf import Dynaconf
 from src.data_utils import write_dataset_local, write_dataset_to_s3, load_latest_dataset
-from src.completion import batch_get_completions, invoke_sagemaker_endpoint
-from src.format import format_prompt_as_xml, format_prompt
-import os
-from transformers import AutoTokenizer
-import pandas as pd
-from src.completion import batch_get_completions
-from src.format import format_prompt_as_xml
-from src.prompt_tones import master_sys_prompt, get_prompt, get_all_tones, Tone
-from tqdm import tqdm
+from src.prompt_tones import get_prompt, Tone
 from src.model_router import route_completion
 
 def run_inference(
@@ -85,6 +76,6 @@ def run_inference(
             d.loc[mask, "rewrite"] = cleaned_output
             d.loc[mask, "inference_model"] = model_name
 
-    write_dataset_local(d, "~/data", "all-tones")
+    write_dataset_local(d, "./data", "all-tones")
     if upload_s3:
         write_dataset_to_s3(d, settings.s3_bucket, "inference/all", "csv")

--- a/src/action_llm_judge.py
+++ b/src/action_llm_judge.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Optional
 from dynaconf import Dynaconf
 from src.data_utils import write_dataset_local, write_dataset_to_s3, load_latest_dataset
 from src.prompts_judge import generate_input_prompt, generate_system_prompt, get_rubric, rewrite_prompt
-from src.completion import batch_get_completions, invoke_sagemaker_endpoint, invoke_ollama_endpoint
+from src.completion import batch_get_bedrock_completions, invoke_sagemaker_endpoint, invoke_ollama_endpoint
 from transformers import AutoTokenizer
 import re
 import boto3
@@ -72,7 +72,7 @@ def process_tone_data(
     
     # Get completions
     sys_prompts, user_prompts = zip(*prompts)
-    completions = batch_get_completions(
+    completions = batch_get_bedrock_completions(
         model_name, 
         client, 
         user_prompts, 
@@ -137,7 +137,7 @@ def judge(
         d.loc[mask, dmt.columns] = dmt.values
     
     # Save results
-    write_dataset_local(d, "~/data", "all-tones")
+    write_dataset_local(d, "./data", "all-tones")
     if upload_s3:
         write_dataset_to_s3(d, settings.s3_bucket, "inference/all", "csv")
 
@@ -160,7 +160,7 @@ def rewrite_judge(
     """
     d = pd.DataFrame({'input': queries, 'output': answers})
     prompts = [rewrite_prompt(q, a) for q, a in zip(queries, answers)]
-    d['rewrite_score'] = batch_get_completions(
+    d['rewrite_score'] = batch_get_bedrock_completions(
         model_id, 
         bedrock_client,
         prompts,

--- a/src/completion.py
+++ b/src/completion.py
@@ -56,7 +56,7 @@ def get_bedrock_completion(settings, prompt, system_prompt=None):
                 )
 
             response = bedrock_client.converse(**converse_api_params)
-            return response['output']['message']['content'][0]['text']
+            return [response['output']['message']['content'][0]['text']]
 
         except ClientError as err:
             message = err.response['Error']['Message']
@@ -202,7 +202,7 @@ def invoke_sagemaker_endpoint(payload, endpoint_name="Phi-3-5-mini-instruct", re
 
 
 def invoke_ollama_endpoint(payload,
-                           endpoint_name="phi3",
+                           endpoint_name,
                            url="127.0.0.1:11434"):
 
     request_body = {


### PR DESCRIPTION
### Notes

- Move some args to settings
- Always get AWS account as the current AWS account to avoid hardcoding it in settings or providing as arg
- Refactor inputs of generate_tone_data
- Rename variables ```d``` and ```t``` in ```process_raw_output```
-  Ensure get_completion always returns the same type (List[str]).
- Make ```endpoint_name``` mandatory in ```invoke_ollama_endpoint```.

### Testing

All of the below run successfully, although the outputs are sometimes nonsensical, e.g. repeating the prompt in the output.

- ```python3.12 main.py generate --type witty --model haiku-3-5-cross```
- ```python3.12 main.py generate --type witty --model phi-3-ollama```
- ```python3.12 main.py generate --type witty --model phi-3-5-4B```
- ```python3.12 main.py inference --model phi-3-ollama```