### PR TITLE
fix: validate model exists in settings.toml

### DIFF
--- a/src/wraval/main.py
+++ b/src/wraval/main.py
@@ -17,6 +17,7 @@ from wraval.actions.action_deploy import deploy
 from wraval.actions.action_examples import get_examples
 from wraval.actions.action_human_judge_upload import upload_human_judge
 import os
+import re
 import typer
 from typing import Optional
 from enum import Enum
@@ -39,6 +40,18 @@ class ToneType(str, Enum):
     SUMMARIZE = "summarize"
 
 
+SETTINGS_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "..", "config", "settings.toml"
+)
+
+
+def _known_models() -> list[str]:
+    """Return the list of model section names defined in settings.toml."""
+    with open(SETTINGS_PATH, "r") as f:
+        sections = re.findall(r"^\[([^]]+)\]", f.read(), re.MULTILINE)
+    return sorted(s for s in sections if s != "default")
+
+
 def get_settings(
     model: str = "haiku-3",
     tone: ToneType = ToneType.ALL,
@@ -46,12 +59,18 @@ def get_settings(
     local_tokenizer_path: Optional[str] = None,
 ) -> Dynaconf:
     """Get settings with the specified configuration."""
+    # Match Dynaconf's case_sensitive=False semantics so the validation
+    # doesn't reject names that Dynaconf itself would accept.
+    known_lower = {m.lower() for m in _known_models()}
+    if model.lower() != "default" and model.lower() not in known_lower:
+        raise ValueError(
+            f"Unknown model '{model}'. "
+            f"Add a [{model}] section to config/settings.toml, or pick one of: "
+            f"{', '.join(_known_models())}."
+        )
+
     settings = Dynaconf(
-        settings_files=[
-            os.path.join(
-                os.path.dirname(__file__), "..", "..", "config", "settings.toml"
-            )
-        ],
+        settings_files=[SETTINGS_PATH],
         env=f"default,{model}",
         environments=True,
         case_sensitive=False,


### PR DESCRIPTION
## Summary

Closes #27.

Calling `wraval` with a `--model` value that has no matching `[<model>]` section in `config/settings.toml` blows up later in `get_settings()` at `settings.endpoint_type` with `AttributeError: 'Settings' object has no attribute 'ENDPOINT_TYPE'`, because Dynaconf silently loads nothing for the missing env and the default values never get attached.

This adds a small preflight check that validates `model` against the section names actually present in `settings.toml` before Dynaconf is instantiated, and raises a `ValueError` listing the available models so the user can see what they typed wrong.

## What changed

- `src/wraval/main.py`: extracted the settings file path to a module constant, added `_known_models()` (regex over `settings.toml` for section headers, ignoring `[default]`), and added a case-insensitive validation step inside `get_settings()` that matches the Dynaconf `case_sensitive=False` semantics introduced in #28.
- No new dependencies. Stdlib `re` only.

## Behavior

Before:
```
$ wraval inference --model totally-bogus
... (later)
AttributeError: 'Settings' object has no attribute 'ENDPOINT_TYPE'
```

After:
```
$ wraval inference --model totally-bogus
ValueError: Unknown model 'totally-bogus'. Add a [totally-bogus] section to config/settings.toml,
or pick one of: haiku-3, haiku-3-5, haiku-3-5-cross, haiku-4-5, nova-lite, phi-3-5-4B,
phi-3-ollama, phi-4-4B, qwen-2-5-1-5B, qwen-3-0-6B, qwen-3-1-7B, qwen-3-1-7B-async,
qwen-3-4B, qwen-3-4B-async, sonnet-3, sonnet-3-5.
```

## Test plan

Repo currently has no test suite. Verified manually that:
- known model names load through (e.g. `haiku-3`)
- `default` is accepted explicitly
- case-insensitive matches go through (e.g. `Haiku-3`, `HAIKU-3`)
- unknown names raise `ValueError` with the full list of available sections
- empty string raises `ValueError`